### PR TITLE
Resolve a NU1608 warning in the ServerlessBlog.Functions.Net46.csproj

### DIFF
--- a/ServerlessBlog.Functions.Net46/ServerlessBlog.Functions.Net46.csproj
+++ b/ServerlessBlog.Functions.Net46/ServerlessBlog.Functions.Net46.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerlessBlog.Model\ServerlessBlog.Model.csproj" />

--- a/ServerlessBlog.Runtime/ServerlessBlog.Runtime.csproj
+++ b/ServerlessBlog.Runtime/ServerlessBlog.Runtime.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
     <PackageReference Include="Handlebars.Net" Version="1.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi, I found a NU1608 warning in the ServerlessBlog.Functions.Net46.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.NET.Sdk.Functions 1.0.6 requires Newtonsoft.Json (= 9.0.1) but version Newtonsoft.Json 10.0.3 was resolved.`

This fix can remove this warnings from AzureFromTheTrenches.ServerlessBlog's dependency graph.
Hope the PR can help you.

Best regards,
sucrose